### PR TITLE
Run PHPunit tests for the Guardr Profile in Guardr Project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 sudo: false
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   # Run a single unit test to verfiy the testing setup.
   - ./vendor/bin/phpunit -c ./web/core ./web/core/modules/system/tests/src/Unit/SystemRequirementsTest.php
   # Run Guardr tests
-  - ./vendor/bin/phpunit -c ./web/core --group guardr
+  - ./vendor/bin/phpunit -c ./web/core --group guardr --testsuite functional
   - ./vendor/bin/drush
   - if [[ $RELEASE = stable ]]; then ./vendor/bin/drupal; fi;
   # Check for available security updates

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   # Run a single unit test to verfiy the testing setup.
   - ./vendor/bin/phpunit -c ./web/core ./web/core/modules/system/tests/src/Unit/SystemRequirementsTest.php
   # Run Guardr tests
-  - ./vendor/bin/phpunit -c ./web/core -group guardr
+  - ./vendor/bin/phpunit -c ./web/core --group guardr
   - ./vendor/bin/drush
   - if [[ $RELEASE = stable ]]; then ./vendor/bin/drupal; fi;
   # Check for available security updates

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - SIMPLETEST_DB=sqlite://tmp/site.sqlite
     - SIMPLETEST_BASE_URL="http://127.0.0.1:8080"
+    - SYMFONY_DEPRECATIONS_HELPER=disabled
   matrix:
     - RELEASE=stable COMPOSER_CHANNEL=stable
     # - RELEASE=dev COMPOSER_CHANNEL=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ script:
   - until curl -s $SIMPLETEST_BASE_URL; do true; done > /dev/null
   # Run a single unit test to verfiy the testing setup.
   - ./vendor/bin/phpunit -c ./web/core ./web/core/modules/system/tests/src/Unit/SystemRequirementsTest.php
+  # Run Guardr tests
+  - ./vendor/bin/phpunit -c ./web/core -group guardr
   - ./vendor/bin/drush
   - if [[ $RELEASE = stable ]]; then ./vendor/bin/drupal; fi;
   # Check for available security updates

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "drupal/core": "^8.8.0",
         "drupal/core-composer-scaffold": "^8.8.0",
         "drush/drush": "^9.7.1 | ^10.0.0",
-        "drupal/guardr": "^1.0",
-        "drupal/guardr_core": "1.x-dev",
+        "drupal/guardr": "1.x-dev",
+        "drupal/guardr_core": "^1.0",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0",
         "zaporylie/composer-drupal-optimizations": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "drupal/core": "^8.8.0",
         "drupal/core-composer-scaffold": "^8.8.0",
         "drush/drush": "^9.7.1 | ^10.0.0",
-        "drupal/guardr": "^1.0",
+        "drupal/guardr": "1.x-dev",
         "drupal/guardr_core": "^1.0",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "drupal/core": "^8.8.0",
         "drupal/core-composer-scaffold": "^8.8.0",
         "drush/drush": "^9.7.1 | ^10.0.0",
-        "drupal/guardr": "1.x-dev",
+        "drupal/guardr": "^1.0",
         "drupal/guardr_core": "^1.0",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal/core-composer-scaffold": "^8.8.0",
         "drush/drush": "^9.7.1 | ^10.0.0",
         "drupal/guardr": "^1.0",
-        "drupal/guardr_core": "^1.0",
+        "drupal/guardr_core": "1.x-dev",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0",
         "zaporylie/composer-drupal-optimizations": "^1.0"


### PR DESCRIPTION
* Setup functional tests to run successfully
* Removed PHP 7.1 jobs since 7.1 is no longer supported by the PHP community